### PR TITLE
Add requirements. Rename variables. Private repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Atlantis on GKE with Terraform
 
-These Terraform configuration provision an [Atlantis][atlantis] cluster on
+These Terraform configurations provision an [Atlantis][atlantis] cluster on
 [Google Kubernetes Engine][gke] using [HashiCorp Terraform][terraform] as the
 provisioning tool.
 
@@ -18,8 +18,15 @@ provisioning tool.
   needed.
 
 - **Automatic GitHub Repo Creation & Configuration** - Automatically creates a
-  dedicated GitHub repository with the Atlantis webhook configured
+  dedicated private GitHub repository with the Atlantis webhook configured
   automatically.
+
+## Requirements
+1. A GCP Organization (see https://cloud.google.com/resource-manager/docs/quickstart-organizations)
+because these configurations create a new project which (through Terraform) must be associated with an
+organization.
+2. A GitHub Organization (not a personal account) because the Terraform GitHub provider
+does not yet support personal accounts: https://github.com/terraform-providers/terraform-provider-github/issues/45
 
 ## Tutorial
 
@@ -123,3 +130,4 @@ limitations under the License.
 [gcs]: https://cloud.google.com/storage
 [gke]: https://cloud.google.com/kubernetes-engine
 [terraform]: https://www.terraform.io
+[sdk]: https://cloud.google.com/sdk/

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -12,7 +12,7 @@ resource "github_repository" "repo" {
   description  = "Terraform Atlantis Demo"
   homepage_url = "https://www.runatlantis.io/"
 
-  private       = false
+  private       = true
   has_issues    = false
   has_wiki      = false
   has_downloads = false

--- a/terraform/k8s.tf
+++ b/terraform/k8s.tf
@@ -65,12 +65,12 @@ resource "kubernetes_pod" "pod" {
 
       env {
         name  = "ATLANTIS_GH_USER"
-        value = "${var.atlantis_user}"
+        value = "${var.atlantis_github_user}"
       }
 
       env {
         name  = "ATLANTIS_GH_TOKEN"
-        value = "${var.atlantis_user_token}"
+        value = "${var.atlantis_github_user_token}"
       }
 
       env {
@@ -80,7 +80,7 @@ resource "kubernetes_pod" "pod" {
 
       env {
         name  = "ATLANTIS_REPO_WHITELIST"
-        value = "github.com/sethvargo-demos/*"
+        value = "${var.atlantis_repo_whitelist}"
       }
 
       env {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -60,11 +60,13 @@ variable "google_account_email" {
 }
 
 variable "github_token" {
-  type = "string"
+  type        = "string"
+  description = "GitHub token with permissions to create the demo repo."
 }
 
 variable "github_organization" {
-  type = "string"
+  type        = "string"
+  description = "GitHub organization to create demo repo in. Won't work with a personal account."
 }
 
 variable "atlantis_version" {
@@ -72,10 +74,17 @@ variable "atlantis_version" {
   default = "latest"
 }
 
-variable "atlantis_user" {
-  type = "string"
+variable "atlantis_github_user" {
+  type        = "string"
+  description = "GitHub username for Atlantis."
 }
 
-variable "atlantis_user_token" {
-  type = "string"
+variable "atlantis_github_user_token" {
+  type        = "string"
+  description = "GitHub token for Atlantis user."
+}
+
+variable "atlantis_repo_whitelist" {
+  type        = "string"
+  description = "Whitelist for what repos Atlantis will operate on, ex. github.com/sethvargo-demos/*"
 }


### PR DESCRIPTION
Thanks for putting this all together. It's quite impressive how much it orchestrates for you.

I got this running myself with some work. The main issues for me were around not having a GCP organization and having to manually enable some APIs via the GCP console. I ended up deploying it into an existing project by modifying some of the tf. I think it's possible to refactor to allow deploying into an existing project however in the meantime it might be best to document the requirements.

I also realized that the demo repo that was created has a `credentials.json` file that contain the keys for the Atlantis service account that gets created. I'm guessing this is necessary for Atlantis to be able to run the demo Terraform however am I wrong in thinking that it's dangerous to put that in a public repo? As such I've moved the repo to private. The other way would be for Atlantis running in the Pod to have permissions to perform the TF actions but I'm not familiar enough with GCP to know how to give it those permissions.

- Add list of requirements to the README.
- Rename some variables and add descriptions so it's clear what they do.
- Make GitHub repo private because it contains the private keys for a
GCP service account.